### PR TITLE
DD-1946: upgrade parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans</groupId>
         <artifactId>dd-parent</artifactId>
-        <version>1.9.0</version>
+        <version>1.10.0</version>
     </parent>
     <artifactId>dd-vault-catalog-cli</artifactId>
     <version>1.0.1-SNAPSHOT</version>


### PR DESCRIPTION
Fixes DD-

# Description of changes


# How tested

With `v. 6.7.1 build DANS-DataStation-PATCH-7` after deploying services with parent-v1.10.0 and

    deploy.py  -e configure_nfs_client_archaeology_mount_state=mounted -t configure-nfs-client dev_transfer
    curl -X PUT -d s3kretKey http://localhost:8080/api/admin/settings/:BlockedApiKey
    curl -X PUT -d unblock-key http://localhost:8080/api/admin/settings/:BlockedApiPolicy

Tried variations of `start.sh --help`




# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/core-systems
