### PR TITLE
DD-2384 Implement delete-dataset-version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <main-class>nl.knaw.dans.catalogcli.VaultCatalogCli</main-class>
         <command-name>vault-catalog</command-name>
-        <dd-vault-catalog-api.version>1.2.0-SNAPSHOT</dd-vault-catalog-api.version>
+        <dd-vault-catalog-api.version>1.2.0</dd-vault-catalog-api.version>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <main-class>nl.knaw.dans.catalogcli.VaultCatalogCli</main-class>
         <command-name>vault-catalog</command-name>
-        <dd-vault-catalog-api.version>1.1.1-SNAPSHOT</dd-vault-catalog-api.version>
+        <dd-vault-catalog-api.version>1.2.0-SNAPSHOT</dd-vault-catalog-api.version>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <main-class>nl.knaw.dans.catalogcli.VaultCatalogCli</main-class>
         <command-name>vault-catalog</command-name>
-        <dd-vault-catalog-api.version>1.0.0</dd-vault-catalog-api.version>
+        <dd-vault-catalog-api.version>1.1.1-SNAPSHOT</dd-vault-catalog-api.version>
     </properties>
     <dependencies>
         <dependency>

--- a/src/main/java/nl/knaw/dans/catalogcli/VaultCatalogCli.java
+++ b/src/main/java/nl/knaw/dans/catalogcli/VaultCatalogCli.java
@@ -23,6 +23,7 @@ import nl.knaw.dans.catalogcli.client.ApiClient;
 import nl.knaw.dans.catalogcli.client.DefaultApi;
 import nl.knaw.dans.catalogcli.command.AddDataset;
 import nl.knaw.dans.catalogcli.command.CreateSkeletonRecord;
+import nl.knaw.dans.catalogcli.command.DeleteVersionExport;
 import nl.knaw.dans.catalogcli.command.GetUnconfirmedVersionExports;
 import nl.knaw.dans.catalogcli.command.SetArchivedTimestamp;
 import nl.knaw.dans.catalogcli.config.VaultCatalogConfig;
@@ -62,6 +63,7 @@ public class VaultCatalogCli extends AbstractCommandLineApp<VaultCatalogConfig> 
         commandLine
             .addSubcommand(new CreateSkeletonRecord(api))
             .addSubcommand(new AddDataset(api))
+            .addSubcommand(new DeleteVersionExport(api))
             .addSubcommand(new GetUnconfirmedVersionExports(api, objectMapper))
             .addSubcommand(new SetArchivedTimestamp(api));
     }

--- a/src/main/java/nl/knaw/dans/catalogcli/command/DeleteVersionExport.java
+++ b/src/main/java/nl/knaw/dans/catalogcli/command/DeleteVersionExport.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.catalogcli.command;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import nl.knaw.dans.catalogcli.client.ApiException;
+import nl.knaw.dans.catalogcli.client.DefaultApi;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+import java.util.concurrent.Callable;
+
+@Command(name = "delete-version-export",
+         mixinStandardHelpOptions = true,
+         description = "Deletes a dataset version export. If it is the only version export for the parent dataset, the parent dataset is also deleted.")
+@RequiredArgsConstructor
+public class DeleteVersionExport implements Callable<Integer> {
+    @NonNull
+    private final DefaultApi api;
+
+    @Parameters(index = "0", paramLabel = "<urn>", description = "The NBN of the dataset.")
+    private String nbn;
+
+    @Parameters(index = "1", paramLabel = "<version>", description = "The OCFL object version number to delete.")
+    private Integer version;
+
+    @Override
+    public Integer call() {
+        try {
+            api.deleteVersionExport(nbn, version);
+            System.err.println("Successfully deleted version export " + nbn + " " + version);
+        }
+        catch (ApiException e) {
+            System.err.println("Error deleting version export: " + e.getMessage());
+            return 1;
+        }
+        return 0;
+    }
+}

--- a/src/main/java/nl/knaw/dans/catalogcli/command/DeleteVersionExport.java
+++ b/src/main/java/nl/knaw/dans/catalogcli/command/DeleteVersionExport.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import nl.knaw.dans.catalogcli.client.ApiException;
 import nl.knaw.dans.catalogcli.client.DefaultApi;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 import java.util.concurrent.Callable;
@@ -38,10 +39,13 @@ public class DeleteVersionExport implements Callable<Integer> {
     @Parameters(index = "1", paramLabel = "<version>", description = "The OCFL object version number to delete.")
     private Integer version;
 
+    @Option(names = {"-f", "--force"}, description = "Force deletion even if it's not the latest version.")
+    private boolean force;
+
     @Override
     public Integer call() {
         try {
-            api.deleteVersionExport(nbn, version);
+            api.deleteVersionExport(nbn, version, force);
             System.err.println("Successfully deleted version export " + nbn + " " + version);
         }
         catch (ApiException e) {


### PR DESCRIPTION
Fixes DD-2384

# Description of changes
This pull request adds a new CLI command for deleting dataset version exports and updates the dependency on the Vault Catalog API. The main changes are:

**New Feature: Delete Version Export Command**
- Added a new `delete-version-export` subcommand to the CLI, allowing users to delete a specific dataset version export, with an option to force deletion even if it's not the latest version. If the deleted export is the only one for its dataset, the parent dataset is also removed. (`src/main/java/nl/knaw/dans/catalogcli/command/DeleteVersionExport.java` [[1]](diffhunk://#diff-7c835c364e27f708233d16266c4ef9c403c9a2d4286064673a58723a7d99f16eR1-R57) `src/main/java/nl/knaw/dans/catalogcli/VaultCatalogCli.java` [[2]](diffhunk://#diff-c955927040e8d770c1aca9e73934016696038839d8de9e4d7dedc4f2421edbf9R26) [[3]](diffhunk://#diff-c955927040e8d770c1aca9e73934016696038839d8de9e4d7dedc4f2421edbf9R66)

**Dependency Updates**
- Updated the `dd-vault-catalog-api` dependency version from `1.0.0` to `1.2.0` in `pom.xml` to support the new API features required by the command.

# Notify
@DANS-KNAW/core-systems
